### PR TITLE
Bump dependencies to latest major versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3 ]
+        php: [ 8.4 ]
 
     name: P${{ matrix.php }} - ${{ matrix.os}}
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}
@@ -44,7 +44,7 @@ jobs:
       # Code coverage
 
       - name: Generate coverage report
-        run: vendor/bin/phpunit --coverage-clover coverage.xml
+        run: vendor/bin/pest --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/styleci.yml
+++ b/.github/workflows/styleci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.1, 8.2, 8.3, 8.4 ]
+        php: [ 8.3, 8.4 ]
 
     name: P${{ matrix.php }} - ${{ matrix.os}}
 

--- a/composer.json
+++ b/composer.json
@@ -5,25 +5,24 @@
     "keywords": ["library", "mpesa"],
     "license": "MIT",
     "require": {
-        "php": "^8.0",
+        "php": "^8.3",
         "ext-json": "*",
         "ext-openssl": "*",
-        "doctrine/dbal": "^3.9",
         "guzzlehttp/guzzle": "^7.9",
-        "illuminate/cache": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/container": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/routing": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/cache": "^11.0|^12.0",
+        "illuminate/container": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/routing": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0",
         "myclabs/deep-copy": "^1.13"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.35",
-        "pestphp/pest": "^2.36",
-        "pestphp/pest-plugin-laravel": "^2.4",
-        "phpstan/phpstan": "^1.12",
-        "phpunit/phpunit": "^10.5",
-        "squizlabs/php_codesniffer": "3.12"
+        "orchestra/testbench": "^9.0|^10.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^11.5|^12.0",
+        "squizlabs/php_codesniffer": "^3.12|^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Require PHP ^8.3, Laravel ^11.0|^12.0 (drop EOL Laravel 8/9/10)
- Remove doctrine/dbal (unused directly, Laravel 11+ handles schema natively)
- Upgrade dev tooling: Pest 3/4, PHPUnit 11/12, PHPStan 2, Testbench 9/10
- Update CI matrix to PHP 8.3/8.4, bump GH Actions cache/codecov versions
- Switch codecov workflow from phpunit to pest for coverage

## Test plan
- [ ] CI passes on PHP 8.3 and 8.4
- [ ] `composer install` resolves cleanly
- [ ] All existing tests pass with Pest 3/4
- [ ] PHPStan 2 analysis passes at level 4
- [ ] Code coverage report generates correctly